### PR TITLE
Add auto load and save controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 <h3>💾 Сохранение и загрузка</h3>
 <button onclick="exportData()">💾 Экспорт JSON</button>
 <button onclick="downloadCraftsFile()">Скачать готовый набор крафтов</button>
+<button onclick="saveDataToSite()">Обновить на сайте</button>
+<button onclick="clearData()">Очистка</button>
 <input id="loadFile" onchange="importData(event)" type="file"/>
 </div>
 <div class="wide-card">

--- a/index.html
+++ b/index.html
@@ -13,10 +13,7 @@
 <div class="card">
 <h3>💾 Сохранение и загрузка</h3>
 <button onclick="exportData()">💾 Экспорт JSON</button>
-<button onclick="loadFromSite()">Загрузить с сайта</button>
-<button onclick="saveDataToSite()">Сохранить на сайте</button>
 <button onclick="downloadCraftsFile()">Скачать готовый набор крафтов</button>
-<button onclick="clearData()">Очистка</button>
 <input id="loadFile" onchange="importData(event)" type="file"/>
 </div>
 <div class="wide-card">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
 <div class="card">
 <h3>💾 Сохранение и загрузка</h3>
 <button onclick="exportData()">💾 Экспорт JSON</button>
+<button onclick="saveDataToSite()">Сохранить на сайте</button>
+<button onclick="clearData()">Очистка</button>
 <input id="loadFile" onchange="importData(event)" type="file"/>
 </div>
 <div class="wide-card">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <button onclick="exportData()">💾 Экспорт JSON</button>
 <button onclick="loadFromSite()">Загрузить с сайта</button>
 <button onclick="saveDataToSite()">Сохранить на сайте</button>
+<button onclick="downloadCraftsFile()">Скачать готовый набор крафтов</button>
 <button onclick="clearData()">Очистка</button>
 <input id="loadFile" onchange="importData(event)" type="file"/>
 </div>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <div class="card">
 <h3>💾 Сохранение и загрузка</h3>
 <button onclick="exportData()">💾 Экспорт JSON</button>
+<button onclick="loadFromSite()">Загрузить с сайта</button>
 <button onclick="saveDataToSite()">Сохранить на сайте</button>
 <button onclick="clearData()">Очистка</button>
 <input id="loadFile" onchange="importData(event)" type="file"/>

--- a/script.js
+++ b/script.js
@@ -171,7 +171,8 @@ function calculateResources(rootId = null) {
 
 function exportInitialItems() {
   const resultDiv = document.getElementById("result");
-  const lines = resultDiv.innerHTML.split("<br>").slice(1); // пропускаем заголовок
+  const withoutHeader = resultDiv.innerHTML.replace(/<h3[^>]*>.*?<\/h3>/, "");
+  const lines = withoutHeader.split("<br>");
   const exportObj = {};
   for (const line of lines) {
     const matches = line.match(/\|\s(.+?)\s\|\sКол-во:\s([\d.]+)/);

--- a/script.js
+++ b/script.js
@@ -1,6 +1,5 @@
 
 const items = {};
-const STORAGE_KEY = 'minecraftCraftData';
 let pastedImageURL = "";
 
 const grid = document.getElementById("craftGrid").querySelector("tbody");
@@ -175,10 +174,10 @@ function exportInitialItems() {
   const lines = resultDiv.innerHTML.split("<br>").slice(1); // пропускаем заголовок
   const exportObj = {};
   for (const line of lines) {
-    const matches = line.match(/\|\s(.+?)\s\|\sКол-во:\s(\d+)/);
+    const matches = line.match(/\|\s(.+?)\s\|\sКол-во:\s([\d.]+)/);
     if (matches) {
       const id = matches[1].trim();
-      const qty = parseInt(matches[2], 10);
+      const qty = Math.ceil(parseFloat(matches[2]));
       exportObj[id] = qty;
     }
   }
@@ -197,16 +196,34 @@ function exportData() {
   a.click();
 }
 
-function saveDataToSite() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
-  alert('Данные сохранены на сайте');
+async function saveDataToSite() {
+  const data = JSON.stringify(items, null, 2);
+  if (window.showSaveFilePicker) {
+    try {
+      const handle = await window.showSaveFilePicker({
+        suggestedName: 'minecraft_craft_data (20).json',
+        types: [{ description: 'JSON', accept: { 'application/json': ['.json'] } }]
+      });
+      const writable = await handle.createWritable();
+      await writable.write(data);
+      await writable.close();
+      alert('Файл обновлен');
+      return;
+    } catch (err) {
+      console.error('File save canceled or failed', err);
+    }
+  }
+  const blob = new Blob([data], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'minecraft_craft_data (20).json';
+  a.click();
 }
 
 function clearData() {
   for (const key in items) {
     delete items[key];
   }
-  localStorage.removeItem(STORAGE_KEY);
   renderItemList();
 }
 
@@ -217,12 +234,11 @@ function importData(event) {
     const data = JSON.parse(reader.result);
     Object.assign(items, data);
     renderItemList();
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
   };
   reader.readAsText(file);
 }
 
-function loadDefaultData() {
+function loadFromSite() {
   fetch('minecraft_craft_data (20).json')
     .then(r => r.json())
     .then(data => {
@@ -232,25 +248,8 @@ function loadDefaultData() {
     .catch(err => console.error('Error loading default data:', err));
 }
 
-function loadFromStorage() {
-  const saved = localStorage.getItem(STORAGE_KEY);
-  if (saved) {
-    try {
-      const data = JSON.parse(saved);
-      Object.assign(items, data);
-      renderItemList();
-      return true;
-    } catch (e) {
-      console.error('Failed to parse saved data', e);
-    }
-  }
-  return false;
-}
-
 document.addEventListener('DOMContentLoaded', () => {
-  if (!loadFromStorage()) {
-    loadDefaultData();
-  }
+  loadFromSite();
 });
 
 

--- a/script.js
+++ b/script.js
@@ -196,6 +196,21 @@ function exportData() {
   a.click();
 }
 
+function saveDataToSite() {
+  const blob = new Blob([JSON.stringify(items, null, 2)], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "minecraft_craft_data (20).json";
+  a.click();
+}
+
+function clearData() {
+  for (const key in items) {
+    delete items[key];
+  }
+  renderItemList();
+}
+
 function importData(event) {
   const file = event.target.files[0];
   const reader = new FileReader();
@@ -206,6 +221,18 @@ function importData(event) {
   };
   reader.readAsText(file);
 }
+
+function loadDefaultData() {
+  fetch('minecraft_craft_data (20).json')
+    .then(r => r.json())
+    .then(data => {
+      Object.assign(items, data);
+      renderItemList();
+    })
+    .catch(err => console.error('Error loading default data:', err));
+}
+
+document.addEventListener('DOMContentLoaded', loadDefaultData);
 
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/script.js
+++ b/script.js
@@ -222,10 +222,17 @@ async function saveDataToSite() {
 }
 
 function downloadCraftsFile() {
-  const a = document.createElement('a');
-  a.href = 'minecraft_craft_data (20).json';
-  a.download = 'minecraft_craft_data (20).json';
-  a.click();
+  const fileName = 'minecraft_craft_data (20).json';
+  fetch(encodeURI(fileName))
+    .then(r => r.blob())
+    .then(blob => {
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = fileName;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    })
+    .catch(err => console.error('Error downloading file:', err));
 }
 
 function clearData() {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 
 const items = {};
+const STORAGE_KEY = 'minecraftCraftData';
 let pastedImageURL = "";
 
 const grid = document.getElementById("craftGrid").querySelector("tbody");
@@ -197,17 +198,15 @@ function exportData() {
 }
 
 function saveDataToSite() {
-  const blob = new Blob([JSON.stringify(items, null, 2)], { type: "application/json" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = "minecraft_craft_data (20).json";
-  a.click();
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  alert('Данные сохранены на сайте');
 }
 
 function clearData() {
   for (const key in items) {
     delete items[key];
   }
+  localStorage.removeItem(STORAGE_KEY);
   renderItemList();
 }
 
@@ -218,6 +217,7 @@ function importData(event) {
     const data = JSON.parse(reader.result);
     Object.assign(items, data);
     renderItemList();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
   };
   reader.readAsText(file);
 }
@@ -232,7 +232,26 @@ function loadDefaultData() {
     .catch(err => console.error('Error loading default data:', err));
 }
 
-document.addEventListener('DOMContentLoaded', loadDefaultData);
+function loadFromStorage() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      const data = JSON.parse(saved);
+      Object.assign(items, data);
+      renderItemList();
+      return true;
+    } catch (e) {
+      console.error('Failed to parse saved data', e);
+    }
+  }
+  return false;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!loadFromStorage()) {
+    loadDefaultData();
+  }
+});
 
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/script.js
+++ b/script.js
@@ -221,6 +221,13 @@ async function saveDataToSite() {
   a.click();
 }
 
+function downloadCraftsFile() {
+  const a = document.createElement('a');
+  a.href = 'minecraft_craft_data (20).json';
+  a.download = 'minecraft_craft_data (20).json';
+  a.click();
+}
+
 function clearData() {
   for (const key in items) {
     delete items[key];


### PR DESCRIPTION
## Summary
- autoload `minecraft_craft_data (20).json` on page load
- add save, clear and load controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d419079c8832e81e8b39b072da997